### PR TITLE
feat: French requirements 1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ dac7 encrypt -z -E PROD ${filename} > ${filename}.gz.gpg
 
 This repository is focused on the French version of DAC7, the requirements of
 which have been published by the _Direction générale des Finances publiques_,
-or DGFiP, on October 24, 2024 ([_cahier des charges_ v1.4][dgfip-cdc],
+or DGFiP, on January 6, 2025 ([_cahier des charges_ v1.5][dgfip-cdc],
 [schema v1.1][dgfip-schema]
 :fr:).
 They differ from the
@@ -357,7 +357,7 @@ make schemas
   - a "naming convention" for the file
 
 [dgfip]: https://www.impots.gouv.fr/transfert-dinformations-en-application-des-dispositifs-dpi-dac7-plateformes-deconomie-collaborative
-[dgfip-cdc]: https://www.impots.gouv.fr/sites/default/files/media/1_metier/3_partenaire/tiers_declarants/cdc_td_bilateral/cdc-dac7-v.1.4.pdf
+[dgfip-cdc]: https://www.impots.gouv.fr/sites/default/files/media/1_metier/3_partenaire/tiers_declarants/cdc_td_bilateral/cdc-dac7-v.1.5.pdf
 [dgfip-naming]: https://www.impots.gouv.fr/sites/default/files/media/1_metier/3_partenaire/tiers_declarants/cdc_td_bilateral/nommage_collecte-dpi-dac7.pdf
 [dgfip-schema]: https://www.impots.gouv.fr/sites/default/files/media/1_metier/3_partenaire/tiers_declarants/cdc_td_bilateral/schema-xsd-de-collecte-dpi-dac7---revenus-2024.zip
 [oecd]: https://www.oecd.org/tax/exchange-of-tax-information/model-rules-for-reporting-by-platform-operators-with-respect-to-sellers-in-the-sharing-and-gig-economy.htm

--- a/cli/stubs/factory.pyi
+++ b/cli/stubs/factory.pyi
@@ -1,0 +1,9 @@
+from typing import Any
+
+class Factory:
+    def create(self, **kwargs: dict) -> dict: ...
+
+Faker: Any
+SubFactory: Any
+LazyAttribute: Any
+List: Any

--- a/cli/tests/dpi/conftest.py
+++ b/cli/tests/dpi/conftest.py
@@ -1,0 +1,86 @@
+from unittest.mock import MagicMock
+
+import factory
+import pytest
+
+from dac7.models.enums import CountryCode
+from dac7.models.enums import CurrencyCode
+from dac7.models.enums import EUCountryCode
+
+
+@pytest.fixture
+def mock_declaration():
+    return MagicMock()
+
+
+class AddressData(factory.Factory):
+    class Meta:
+        model = dict
+
+    country_code = factory.Faker("random_element", elements=[code.value for code in CountryCode])
+    street = factory.Faker("street_address")
+    post_code = factory.Faker("postcode")
+    city = factory.Faker("city")
+
+
+class OtherActivitiesData(factory.Factory):
+    class Meta:
+        model = dict
+
+    currency_code = factory.Faker("random_element", elements=[code.value for code in CurrencyCode])
+    activities_number_q1 = factory.Faker("pyint", max_value=1000)
+    activities_number_q2 = factory.Faker("pyint", max_value=1000)
+    activities_number_q3 = factory.Faker("pyint", max_value=1000)
+    activities_number_q4 = factory.Faker("pyint", max_value=1000)
+    consideration_amount_q1 = factory.Faker("pydecimal", positive=True, right_digits=2, max_value=100000)
+    consideration_amount_q2 = factory.Faker("pydecimal", positive=True, right_digits=2, max_value=100000)
+    consideration_amount_q3 = factory.Faker("pydecimal", positive=True, right_digits=2, max_value=100000)
+    consideration_amount_q4 = factory.Faker("pydecimal", positive=True, right_digits=2, max_value=100000)
+    fees_amount_q1 = factory.Faker("pydecimal", positive=True, right_digits=2, max_value=100000)
+    fees_amount_q2 = factory.Faker("pydecimal", positive=True, right_digits=2, max_value=100000)
+    fees_amount_q3 = factory.Faker("pydecimal", positive=True, right_digits=2, max_value=100000)
+    fees_amount_q4 = factory.Faker("pydecimal", positive=True, right_digits=2, max_value=100000)
+    taxes_amount_q1 = factory.Faker("pydecimal", positive=True, right_digits=2, max_value=100000)
+    taxes_amount_q2 = factory.Faker("pydecimal", positive=True, right_digits=2, max_value=100000)
+    taxes_amount_q3 = factory.Faker("pydecimal", positive=True, right_digits=2, max_value=100000)
+    taxes_amount_q4 = factory.Faker("pydecimal", positive=True, right_digits=2, max_value=100000)
+
+
+class TaxIdentificationNumberData(factory.Factory):
+    class Meta:
+        model = dict
+
+    issued_by = "BE"
+    value = factory.Faker("numerify", text="############")
+
+
+class IndividualSellerData(factory.Factory):
+    class Meta:
+        model = dict
+
+    class Params:
+        tax_identification_number = factory.SubFactory(TaxIdentificationNumberData)
+
+    seller_id = "seller-id"
+    name_type = "OECD202"
+    first_name = factory.Faker("first_name")
+    last_name = factory.Faker("last_name")
+    residence_country_code = factory.Faker("random_element", elements=[code.value for code in EUCountryCode])
+    vat_number = None
+    tax_identification_numbers = factory.LazyAttribute(
+        lambda o: [o.tax_identification_number] if o.tax_identification_number else []
+    )
+    birth_date = factory.Faker("date")
+    birth_city = factory.Faker("city")
+    birth_country_code = factory.Faker("random_element", elements=[code.value for code in CountryCode])
+    addresses = factory.List(
+        [
+            factory.SubFactory(AddressData),
+        ]
+    )
+    sale_of_goods = factory.SubFactory(OtherActivitiesData)
+
+
+@pytest.fixture
+def build_individual_seller_data():
+    return IndividualSellerData.create

--- a/cli/tests/dpi/test_individual_sellers.py
+++ b/cli/tests/dpi/test_individual_sellers.py
@@ -1,0 +1,76 @@
+import pytest
+
+from dac7.models.flat import ReportableIndividualSeller
+
+
+@pytest.mark.parametrize(
+    ("country_code", "value"),
+    [
+        ("AT", "999999999"),
+        ("BG", "9999999999"),
+        ("CY", "09999999L"),
+        ("CZ", "999999999"),
+        ("CZ", "9999999999"),
+        ("DE", "99999999999"),
+        ("DK", "9999999999"),
+        ("EE", "99999999999"),
+        ("ES", "99999999L"),
+        ("ES", "L9999999L"),
+        ("ES", "K9999999L"),
+        ("ES", "X9999999L"),
+        ("ES", "Y9999999L"),
+        ("ES", "Z9999999L"),
+        ("ES", "M9999999L"),
+        ("FI", "999999+999L"),
+        ("FI", "999999+9999"),
+        ("FI", "999999-999L"),
+        ("FI", "999999-9999"),
+        ("FI", "999999A999L"),
+        ("FI", "999999A9999"),
+        ("FR", "0999999999999"),
+        ("FR", "1999999999999"),
+        ("FR", "2999999999999"),
+        ("FR", "3999999999999"),
+        ("FR", "99999999999999"),
+        ("FR", "999999999"),
+        ("HR", "99999999999"),
+        ("HU", "9999999999"),
+        ("IE", "9999999L"),
+        ("IE", "9999999LL"),
+        ("IT", "LLLLLL99L99L999L"),
+        ("LT", "99999999999"),
+        ("LU", "9999999999999"),
+        ("LV", "31127509999"),
+        ("LV", "3112750-9999"),
+        ("LV", "329999-99999"),
+        ("LV", "32999999999"),
+        ("MT", "9999999M"),
+        ("MT", "9999999G"),
+        ("MT", "9999999A"),
+        ("MT", "9999999P"),
+        ("MT", "9999999L"),
+        ("MT", "9999999H"),
+        ("MT", "9999999B"),
+        ("MT", "9999999Z"),
+        ("MT", "999999999"),
+        ("NL", "999999999"),
+        ("PL", "9999999999"),
+        ("PL", "99999999999"),
+        ("PT", "999999999"),
+        ("RO", "9999999999999"),
+        ("SE", "999999+9999"),
+        ("SE", "999999-9999"),
+        ("SI", "99999999"),
+        ("SK", "999999999"),
+        ("SK", "9999999999"),
+    ],
+)
+def test_tax_identification_numbers(mock_declaration, build_individual_seller_data, country_code, value):
+    individual_seller_data = build_individual_seller_data(
+        tax_identification_number__issued_by=country_code,
+        tax_identification_number__value=value,
+    )
+    individual_seller = ReportableIndividualSeller(
+        **individual_seller_data,
+    )
+    individual_seller.get_dpi(mock_declaration)

--- a/cli/tests/dpi/test_individual_sellers.py
+++ b/cli/tests/dpi/test_individual_sellers.py
@@ -6,6 +6,7 @@ from dac7.models.flat import ReportableIndividualSeller
 @pytest.mark.parametrize(
     ("country_code", "value"),
     [
+        # EU
         ("AT", "999999999"),
         ("BG", "9999999999"),
         ("CY", "09999999L"),
@@ -63,6 +64,8 @@ from dac7.models.flat import ReportableIndividualSeller
         ("SI", "99999999"),
         ("SK", "999999999"),
         ("SK", "9999999999"),
+        # Non-EU
+        ("AR", "20258743991"),
     ],
 )
 def test_tax_identification_numbers(mock_declaration, build_individual_seller_data, country_code, value):

--- a/examples/4_corrective/declaration.xml
+++ b/examples/4_corrective/declaration.xml
@@ -40,7 +40,7 @@
                     <dpi:Standard>
                         <dpi:IndSellerID>
                             <dpi:ResCountryCode>ES</dpi:ResCountryCode>
-                            <dpi:TIN issuedBy="FR">20258743991</dpi:TIN>
+                            <dpi:TIN issuedBy="AR">20258743991</dpi:TIN>
                             <dpi:Name nameType="OECD202">
                                 <dpi:Title>Mr</dpi:Title>
                                 <dpi:FirstName xnlNameType="OECD208">Carlos</dpi:FirstName>

--- a/examples/4_corrective/input/individual_sellers.json
+++ b/examples/4_corrective/input/individual_sellers.json
@@ -3,7 +3,7 @@
         "residence_country_code": "ES",
         "tax_identification_numbers": [
             {
-                "issued_by": "FR",
+                "issued_by": "AR",
                 "value": "20258743991"
             }
         ],

--- a/poetry.lock
+++ b/poetry.lock
@@ -276,6 +276,39 @@ files = [
 dev = ["Sphinx", "coverage", "flake8", "lxml", "lxml-stubs", "memory-profiler", "memray", "mypy", "tox", "xmlschema (>=2.0.0)"]
 
 [[package]]
+name = "factory-boy"
+version = "3.3.1"
+description = "A versatile test fixtures replacement based on thoughtbot's factory_bot for Ruby."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "factory_boy-3.3.1-py2.py3-none-any.whl", hash = "sha256:7b1113c49736e1e9995bc2a18f4dbf2c52cf0f841103517010b1d825712ce3ca"},
+    {file = "factory_boy-3.3.1.tar.gz", hash = "sha256:8317aa5289cdfc45f9cae570feb07a6177316c82e34d14df3c2e1f22f26abef0"},
+]
+
+[package.dependencies]
+Faker = ">=0.7.0"
+
+[package.extras]
+dev = ["Django", "Pillow", "SQLAlchemy", "coverage", "flake8", "isort", "mongoengine", "mongomock", "mypy", "tox", "wheel (>=0.32.0)", "zest.releaser[recommended]"]
+doc = ["Sphinx", "sphinx-rtd-theme", "sphinxcontrib-spelling"]
+
+[[package]]
+name = "faker"
+version = "33.3.0"
+description = "Faker is a Python package that generates fake data for you."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "Faker-33.3.0-py3-none-any.whl", hash = "sha256:ae074d9c7ef65817a93b448141a5531a16b2ea2e563dc5774578197c7c84060c"},
+    {file = "faker-33.3.0.tar.gz", hash = "sha256:2abb551a05b75d268780b6095100a48afc43c53e97422002efbfc1272ebf5f26"},
+]
+
+[package.dependencies]
+python-dateutil = ">=2.4"
+typing-extensions = "*"
+
+[[package]]
 name = "fancycompleter"
 version = "0.9.1"
 description = "colorful TAB completion for Python prompt"
@@ -779,6 +812,20 @@ pytest = ">=6.2.5"
 dev = ["pre-commit", "pytest-asyncio", "tox"]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+description = "Extensions to the standard Python datetime module"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+files = [
+    {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
+    {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
+]
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
 name = "python-gnupg"
 version = "0.5.3"
 description = "A wrapper for the Gnu Privacy Guard (GPG or GnuPG)"
@@ -801,7 +848,6 @@ files = [
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
-    {file = "PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290"},
     {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
     {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
     {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
@@ -809,16 +855,8 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
-    {file = "PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b"},
     {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
-    {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
-    {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
-    {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
-    {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
-    {file = "PyYAML-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df"},
     {file = "PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"},
@@ -835,7 +873,6 @@ files = [
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
-    {file = "PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6"},
     {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
     {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
     {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
@@ -843,7 +880,6 @@ files = [
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
-    {file = "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5"},
     {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
     {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
     {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
@@ -1077,4 +1113,4 @@ docs = ["Sphinx", "elementpath (>=4.4.0,<5.0.0)", "jinja2", "sphinx-rtd-theme"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<3.14"
-content-hash = "1a9dc3bc38c85c2d7f5944e9eb897de1943cad95bf8703596f0fad3ec4ab964c"
+content-hash = "d801d11b1148c76e154aa989733e8fc2fe2bab34efb33eab4c196abe6d000edf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ pytest-mock = "^3.12.0"
 pdbpp = "^0.10.3"
 virtualenv = "^20.26.2"
 types-requests = "^2.31.0"
+factory-boy = "^3.3.1"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Update following release of version 1.5 of the [French “cahier des charges”](https://www.impots.gouv.fr/sites/default/files/media/1_metier/3_partenaire/tiers_declarants/cdc_td_bilateral/cdc-dac7-v.1.5.pdf)

It seems the only change is about the validation of the individuals' Tax identification numbers.