### PR TITLE
chore(renovate): Add minimum release age 7 days

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,6 +11,7 @@
     "group:allNonMajor"
   ],
   "rebaseWhen": "conflicted",
+  "minimumReleaseAge": "7 days",
   "packageRules": [
     {
       "matchPackageNames": [


### PR DESCRIPTION
> This Renovate configuration does not set a minimum release age. Newly published packages can be    
          malicious or unstable. Add `"minimumReleaseAge": "7 days"` within a `packageRules` entry to wait 7 
          days before proposing updates to newly published package versions. Set `"minimumReleaseAge": false`
          to set an exception for minimal release age for the package rule. Added in: v42                    
          Details: https://sg.run/D8l2q                                                  